### PR TITLE
Add os generated files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ typings/
 
 # The `dist` directory
 dist/
+
+# OS generated files
+.DS_Store


### PR DESCRIPTION
This line in gitignore is needed for everyone developing with Mac.

Possibly add Thumbs.db for Windows? or .swp .swo for vim users?